### PR TITLE
Remove lecture part links from homotopy.html

### DIFF
--- a/homotopy.html
+++ b/homotopy.html
@@ -43,7 +43,6 @@
   <thead>
     <tr>
       <th>Lecture</th>
-      <th>Links</th>
       <th>Topics Covered</th>
       <th>Lecture Notes</th>
     </tr>
@@ -51,11 +50,6 @@
   <tbody>
     <tr>
       <td>Lecture 1</td>
-      <td>
-        <a href="https://drive.google.com/file/d/11FN6fh7JnN0A6olrkIo7mjVLxOu_he4P/view?usp=drive_link" target="_blank">Part 1</a>
-        &nbsp;|&nbsp;
-        <a href="https://drive.google.com/file/d/1YdcB9oF6jk_6tC-ykIVYndU1C61iNiXd/view?usp=drive_link" target="_blank">Part 2</a>
-      </td>
       <td>
         <ul>
           <li>Localization of Categories</li>
@@ -67,11 +61,6 @@
     </tr>
     <tr>
      <td>Lecture 2</td>
-        <td>
-        <a href="https://drive.google.com/file/d/10eWDwufGrMyH8v-Yhb_fpK_Mw1bjICPO/view?usp=drive_link" target="_blank">Part 1</a>
-        &nbsp;|&nbsp;
-        <a href="https://drive.google.com/file/d/1LOUhLej7hO8orzukEqKOjHBFwuf-2flc/view?usp=drive_link" target="_blank">Part 2</a>
-      </td>
       <td>
         <ul>
           <li>Cylinder and Path Objects and Homotopies</li>
@@ -82,26 +71,15 @@
     </tr>
           <tr>
      <td>Lecture 3</td>
-        <td>
-        <a href="https://drive.google.com/file/d/1vq-SIhSVh0iin4M_MpN9xJdE6e4FWlpR/view?usp=drive_link" target="_blank">Part 1</a>
-        &nbsp;|&nbsp;
-        <a href="https://drive.google.com/file/d/1SQ3KnpJxEadXU5SXhyijBo0QlkBAzRhf/view?usp=drive_link" target="_blank">Part 2</a>
-      </td>
       <td>
         <ul>
           <li>The Quillen Model Structure on Top and SSet</li>
           <li>Quillen Adjunctions and Equivalences</li>
         </ul>
       </td>
-    <!--     <td>Soon.</td>-->
        <td><a href="lecture notes/Model_categories_lecture_3.pdf" target="_blank">Lecture 3</a></td> 
     </tr>          <tr>
      <td>Lecture 4</td>
-        <td>
-        <a href="https://drive.google.com/file/d/1O0-8W7RT2clM4PUcZrkdPlXhKpQzgdhT/view?usp=drive_link" target="_blank">Part 1</a>
-        &nbsp;|&nbsp;
-        <a href="https://drive.google.com/file/d/1kl6Ofhl3TD8_kfj6Aj1VpDlZOvREgxBg/view?usp=drive_link" target="_blank">Part 2</a>
-      </td>
       <td>
         <ul>
           <li>Homotopy (Co)limits as Derived Functors</li>
@@ -114,11 +92,6 @@
           <td><a href="lecture notes/Model_categories_lecture_4.pdf" target="_blank">Lecture 4</a></td> 
     </tr>
            <td>Lecture 5</td>
-        <td>
-        <a href="https://drive.google.com/file/d/1RXCXXQA25eO749Rd6JvfL7ZGu0Sc1RFU/view?usp=drive_link" target="_blank">Part 1</a>
-        &nbsp;|&nbsp;
-        <a href="https://drive.google.com/file/d/1Go63yiG70BJ3uQ2npyLwtOXoQVn57KDe/view?usp=drive_link" target="_blank">Part 2</a>
-      </td>
       <td>
         <ul>
           <li>Homotopy Pushouts and Pullbacks as Pushouts and Pullbacks</li>


### PR DESCRIPTION
Removed links to Google Drive for lecture parts in the homotopy table.